### PR TITLE
installx.sh corrections for FUSE

### DIFF
--- a/installx.sh
+++ b/installx.sh
@@ -34,7 +34,7 @@ load_fuse() {
 	# Filesystems in Userspace
 	fuse_pkgs="fuse fuse-utils"
 	extra_pkgs="$extra_pkgs fusefs-lkl e2fsprogs"
-	sysrc kld_list+="fuse"
+	sysrc kld_list+="fusefs"
 }
 
 load_coretemp(){


### PR DESCRIPTION
The module is `fusefs`, not `fuse`. 

<https://www.freebsd.org/cgi/man.cgi?query=fusefs&sektion=5&manpath=FreeBSD#SYNOPSIS>